### PR TITLE
- Mobile detect now being added to the AEJS settings from WP settings…

### DIFF
--- a/admin/class-ae-connect-ae-js-settings-export.php
+++ b/admin/class-ae-connect-ae-js-settings-export.php
@@ -56,6 +56,7 @@ class Ae_JS_Settings_Export {
         $ae_js_settings['auth_window'] = get_option('ae_connect_auth_window') == 'on' ? true : false;
         $ae_js_settings['flow_css'] = get_option('ae_connect_flow_css');
         $ae_js_settings['disable_local_wp_user'] = get_option('ae_connect_disable_local_wp_user') == 'on' ? true : false;
+        $ae_js_settings['mobile_detect'] = get_option('ae_connect_mobile_detect') == 'on' ? true : false;
 
         $ae_js_settings['extra_fields'] = $this->render_extra_fields_settings();
         $ae_js_settings['verify_email'] = get_option('ae_connect_verify_email') == 'on' ? true : false;

--- a/admin/js/ae-connect-shortcode-generator.js
+++ b/admin/js/ae-connect-shortcode-generator.js
@@ -63,7 +63,6 @@ var SCgenerators = {};
 function setSCgeneratorsFromStorage() {
     data = localStorage.getItem('scgens');
     data = JSON.parse(data);
-    console.log(data);
     for(gen in data) {
         let scType = data[gen].scType;
         addGenerator(scType, gen);
@@ -162,7 +161,6 @@ function addGenerator(scType, id = false) {
 
     if(!id) {
         var generatorsOfType = document.getElementsByClassName(wrapperClassName);
-        console.log(generatorsOfType);
 
         do {
             var id = scType+"-"+(generatorsOfType.length +=1);
@@ -184,7 +182,6 @@ function addGenerator(scType, id = false) {
 function generateShortcode(event) {
     const shortCodeConfig = jQuery(event.target).parent(".shortcode-config-inner");
     const id = shortCodeConfig.parent(".shortcode-config").parent("div").attr('id');
-    console.log(id);
     var data = {};
     shortCodeConfig.children('p').each(function () {
         let input = this.querySelector('input');
@@ -236,7 +233,7 @@ function setShortcodeText(shortCodeConfig, data) {
 
 /**
  * Responds to clone removal events and clears clone from the DOM and also from
- * SCgenerators + localStorage 
+ * SCgenerators + localStorage
  */
 function removeGenerator(event) {
     const shortCodeConfig = jQuery(event.target).parent(".shortcode-config");

--- a/public/js/ae-ready.js
+++ b/public/js/ae-ready.js
@@ -32,9 +32,6 @@ function AEJSReady(aeJS) {
 
     registerDOMEventHandlers();
     addAeJsHandlers(aeJS);
-    // jQuery.alert("I am a jquery alert", "Big big title", AeUserHandling.testcloseCallback);
-    // console.log(JSON.stringify(globalAEJS.settings.extra_fields));
-    // console.log(globalAEJS.settings.extra_fields);
 
 }
 
@@ -53,7 +50,6 @@ function addAeJsHandlers(aeJS) {
 }
 
 function flowHandler(event) {
-
     /**
      * @todo toggle onpage flow? How will this effect email verification
      */
@@ -116,7 +112,6 @@ function windowHandler(event) {
 function loginHandler(user, type, sso) {
     AeState.globalLoginType = type;
     noReqFields = !AeUtilities.areRequiredFields(AeState.globalAEJS.settings.extra_fields);
-
     // manually handle extra fields if required-fields won't fire.
     if (AeState.onpageFlow && type == 'registration' && noReqFields
     && AeState.globalSignupState != 3
@@ -196,6 +191,9 @@ function registerDOMEventHandlers() {
 }
 
 function registerOnpageSubmitClickHandler() {
+    jQuery("#ae-onpage-submit").click(function() {
+        AeJsSettings.toggleOnPageFlow(true);
+    });
 
     jQuery("#email-signup").submit(function() { // user clicked the submit button for onpage Email/Password form
         var btn = jQuery('#ae-onpage-submit');
@@ -204,7 +202,6 @@ function registerOnpageSubmitClickHandler() {
         btn.css("color", "white");
         btn.css("background-color", "grey"); // grey out button
 
-        AeJsSettings.toggleOnPageFlow(true);
         AeState.globalSignupState = 1;
     });
 

--- a/public/js/set-aejs-settings.js
+++ b/public/js/set-aejs-settings.js
@@ -24,6 +24,10 @@ AeSettings.prototype = {
             this.AeState.globalAEJS.settings['auth_window'] = this.WpAeJsSettings['auth_window'];
         }
 
+        if (this.WpAeJsSettings['mobile_detect'] != undefined) {
+            this.AeState.globalAEJS.settings['mobile_detect'] = this.WpAeJsSettings['mobile_detect'];
+        }
+
         if (this.WpAeJsSettings['extra_fields'] && this.WpAeJsSettings['extra_fields'].length !== 0) {
             this.AeState.globalAEJS.settings['extra_fields'] = this.WpAeJsSettings['extra_fields'];
         }
@@ -107,7 +111,6 @@ AeSettings.prototype = {
     },
 
     /**
-     * [toggleOnPageFlow description]
      * @param  {Boolean} isOnPageFlow [description]
      * @return {[type]}               [description]
      */


### PR DESCRIPTION
… config

- removed some console logs
- onPageFlow is now toggled on in a click handler for the onpage 
Email/Password form
  - This ensures that the auth window wont hijack the flow before 
onLogin fires
  - Previously, the onpageFlow was toggled onSubmit, which gives AE's 
auth window handling precedence over the WP plugin's JS code.
  - In short, now even if auth_window=false, there are extra fields, but 
none required, the onpage extra fields form will still display.